### PR TITLE
docs: update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ A loudness meter for the `Web Audio API`, based on the [ITU-R BS.1770-5](https:/
 
 [![screenshot](https://github.com/lcweden/loudness-worklet/blob/main/packages/web/public/screenshots/meter.png)](https://lcweden.github.io/loudness-worklet/)
 
-<p align="center"><a href="https://lcweden.github.io/loudness-worklet/">Demo</a></p>
-
 ## Features
 
 - **Loudness Measurement**: Compliant with the **ITU-R BS.1770-5** standard.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 A loudness meter for the `Web Audio API`, based on the [ITU-R BS.1770-5](https://www.itu.int/rec/R-REC-BS.1770) standard and implemented as an AudioWorkletProcessor.
 
-[![screenshot](https://github.com/lcweden/loudness-worklet/blob/main/public/screenshots/meter.png)](https://lcweden.github.io/loudness-worklet/)
+[![screenshot](https://github.com/lcweden/loudness-worklet/blob/main/packages/web/public/screenshots/meter.png)](https://lcweden.github.io/loudness-worklet/)
 
 <p align="center"><a href="https://lcweden.github.io/loudness-worklet/">Demo</a></p>
 


### PR DESCRIPTION
This pull request updates the screenshot and demo link in the `README.md` to reflect the new file path for the meter screenshot under the `packages/web` directory.

- Documentation update:
  * Updated the screenshot image path in `README.md` to point to `packages/web/public/screenshots/meter.png` instead of the previous location.
  * Removed the separate demo link and centered paragraph for a cleaner README layout.