### PR TITLE
fix: loosen progress condition for file selection

### DIFF
--- a/packages/web/src/views/dashboard.tsx
+++ b/packages/web/src/views/dashboard.tsx
@@ -117,7 +117,7 @@ function Dashboard(props: Props) {
                 <FileSlidersIcon size={14} />
                 <select
                   class="w-fit max-w-32 cursor-pointer select-none appearance-none truncate bg-transparent outline-0"
-                  disabled={getProgress() < 100}
+                  disabled={getProgress() < 99}
                   onchange={handleFileSelect}
                 >
                   <Show


### PR DESCRIPTION
This pull request makes a minor adjustment to the file selection dropdown on the dashboard. The dropdown is now enabled when progress reaches 99% instead of requiring a full 100% completion.