### PR TITLE
fix: handle weights fallback

### DIFF
--- a/packages/core/src/processors/loudness-processor.ts
+++ b/packages/core/src/processors/loudness-processor.ts
@@ -33,7 +33,7 @@ class LoudnessProcessor extends AudioWorkletProcessor {
   interval: number;
   previousTime: number = 0;
   attenuation: number = 10 ** (-ATTENUATION_DB / 20);
-  measurements: LoudnessMeasurements[];
+  measurements: LoudnessMeasurements[] = [];
   kWeightingFilters: Repeat<BiquadraticFilter, 2>[][] = [];
   overSamplingFilters: Repeat<FiniteImpulseResponseFilter, 4>[][] = [];
   overSampledValues: number[] = [];
@@ -57,7 +57,6 @@ class LoudnessProcessor extends AudioWorkletProcessor {
 
     this.capacity = capacity || 0;
     this.interval = interval || 0;
-    this.measurements = [];
 
     for (let i = 0; i < numberOfInputs; i++) {
       const mEnergyBufferSize = Math.round(sampleRate * MOMENTARY_WINDOW_SEC);
@@ -146,7 +145,7 @@ class LoudnessProcessor extends AudioWorkletProcessor {
           const highshelfOutput = highshelf.process(sample);
           const kWeightedSample = highpass.process(highshelfOutput);
           const sampleEnergy = kWeightedSample * kWeightedSample;
-          const channelWeight = weights[c] ?? 1.0;
+          const channelWeight = weights ? (weights[c] ?? 1.0) : 1.0;
 
           energy += sampleEnergy * channelWeight;
 


### PR DESCRIPTION
This pull request makes minor improvements to the `LoudnessProcessor` class in `loudness-processor.ts` by ensuring proper initialization of the `measurements` array and making the channel weighting calculation more robust.

- **Initialization improvements:**
  * Ensure the `measurements` array is always initialized as an empty array at declaration, preventing potential issues if the constructor is bypassed.
  * Remove redundant initialization of `measurements` in the constructor, since it is now handled at declaration.

- **Robustness in channel weighting:**
  * Update the channel weighting calculation to safely handle cases where the `weights` array may be undefined, defaulting to a weight of `1.0` if so.