### PR TITLE
release: v1.6.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ This example shows the easiest way to get started with the Loudness Audio Workle
         // Create the loudness worklet node
         const worklet = new AudioWorkletNode(context, "loudness-processor", {
           processorOptions: {
-            interval: 0.1, // every 0.1s a message will be sent
+            interval: 0.02, // every 0.02s a message will be sent
             capacity: 600 // 1 minute of history can be stored
           }
         });
@@ -226,7 +226,7 @@ The `AudioWorkletNode` constructor accepts the following options:
 
 | Option                    | Type       | Required | Default | Description                                                                                          |
 | ------------------------- | ---------- | -------- | ------- | ---------------------------------------------------------------------------------------------------- |
-| processorOptions.interval | `number`   | `No`     | `0.1`   | Message interval in seconds.                                                                         |
+| processorOptions.interval | `number`   | `No`     | `0.02`  | Message interval in seconds.                                                                         |
 | processorOptions.capacity | `number`   | `No`     | `0`     | Maximum seconds of history to keep. If set to `0`, the processor will not limit the history size.   |
 
 #### Example
@@ -238,7 +238,7 @@ const { numberOfChannels, length, sampleRate } = audioBuffer;
 const worklet = new AudioWorkletNode(context, "loudness-processor", {
   processorOptions: {
     capacity: length / sampleRate,
-    interval: 0.1
+    interval: 0.02
   }
 });
 ```

--- a/packages/core/src/processors/loudness-processor.ts
+++ b/packages/core/src/processors/loudness-processor.ts
@@ -85,7 +85,7 @@ class LoudnessProcessor extends AudioWorkletProcessor {
     }
 
     this.capacity = capacity || 0;
-    this.interval = interval || 0.1;
+    this.interval = interval ?? 0.02;
 
     for (let i = 0; i < numberOfInputs; i++) {
       const mEnergyBufferSize = Math.round(sampleRate * MOMENTARY_WINDOW_SEC);

--- a/packages/web/src/hooks/loudness-analysis.hook.tsx
+++ b/packages/web/src/hooks/loudness-analysis.hook.tsx
@@ -30,7 +30,7 @@ function createLoudnessAnalysis() {
 
   async function analyze(
     buffer: AudioBuffer,
-    options?: { capacity?: number; interval: number },
+    options?: { capacity?: number; interval?: number },
   ) {
     const { numberOfChannels, length, sampleRate } = buffer;
     const ctx = new OfflineAudioContext(numberOfChannels, length, sampleRate);
@@ -38,7 +38,7 @@ function createLoudnessAnalysis() {
     await LoudnessWorkletNode.loadModule(ctx);
 
     const capacity = options?.capacity ?? length / sampleRate;
-    const interval = options?.interval ?? 0.1;
+    const interval = options?.interval ?? 0.02;
     const option = { processorOptions: { capacity, interval } };
 
     const sourceNode = new AudioBufferSourceNode(ctx, { buffer });

--- a/packages/web/src/views/dashboard.tsx
+++ b/packages/web/src/views/dashboard.tsx
@@ -28,6 +28,7 @@ function Dashboard(props: Props) {
   const [getBuffer, setBuffer] = createSignal<AudioBuffer>();
   const [getTarget, setTarget] = createSignal<LoudnessStandard>(STANDARDS[0]);
   const getProgress = createMemo(handleProgressChange);
+  const getFiles = createMemo(() => Array.from(props.files));
 
   function handleProgressChange() {
     const buffer = getBuffer();
@@ -41,6 +42,11 @@ function Dashboard(props: Props) {
 
     const { duration } = buffer;
     const { currentTime } = snapshot;
+
+    if (duration - currentTime <= 0.15) {
+      return 100;
+    }
+
     const progress = Math.min(Math.ceil((currentTime / duration) * 100), 100);
 
     return progress;
@@ -48,7 +54,7 @@ function Dashboard(props: Props) {
 
   function handleFileSelect(event: Event) {
     const select = event.target as HTMLSelectElement;
-    const file = Array.from(props.files).find((f) => f.name === select.value);
+    const file = getFiles().find((f) => f.name === select.value);
 
     if (file) {
       handleFileChange(file);
@@ -77,7 +83,7 @@ function Dashboard(props: Props) {
   }
 
   createEffect(() => {
-    const [file] = props.files;
+    const [file] = getFiles();
 
     if (file) {
       handleFileChange(file);
@@ -90,7 +96,7 @@ function Dashboard(props: Props) {
     if (!buffer) return;
 
     clear();
-    analyze(buffer);
+    analyze(buffer, { interval: 0.1 });
   });
 
   return (
@@ -127,10 +133,10 @@ function Dashboard(props: Props) {
                   <Show
                     fallback={<option>-</option>}
                     keyed={true}
-                    when={props.files}
+                    when={getFiles()}
                   >
                     {(files) => (
-                      <For each={Array.from(files)}>
+                      <For each={files}>
                         {(file) => (
                           <option value={file.name}>{file.name}</option>
                         )}


### PR DESCRIPTION
This pull request primarily updates the default `interval` value used for loudness analysis from 0.1 seconds to 0.02 seconds across the codebase and documentation, ensuring more frequent analysis updates. It also introduces minor improvements to the dashboard view for handling file lists and progress calculation.

**Loudness analysis interval update:**

* Changed the default `interval` for loudness analysis from 0.1s to 0.02s in the processor code, analysis hook, and all relevant documentation and usage examples, ensuring more granular loudness measurements. [[1]](diffhunk://#diff-edf8ad15e4dbd7f777d6a8eba6f756e3a69bc0090cc4debd9a9ec57db3483fe9L88-R88) [[2]](diffhunk://#diff-64b10f3e877004745610e42be356bdc89f34dc020edec68f2a61aaebb12bc17aL33-R41) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L102-R102) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L229-R229) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L241-R241)

**Dashboard improvements:**

* Refactored the dashboard to use a memoized `getFiles` function for consistent access to the file list, improving reactivity and performance. [[1]](diffhunk://#diff-90cb28e35b5824aa44096fb6e184ae25507a9e192ff720121de8794ba736d33dR31) [[2]](diffhunk://#diff-90cb28e35b5824aa44096fb6e184ae25507a9e192ff720121de8794ba736d33dR45-R57) [[3]](diffhunk://#diff-90cb28e35b5824aa44096fb6e184ae25507a9e192ff720121de8794ba736d33dL80-R86) [[4]](diffhunk://#diff-90cb28e35b5824aa44096fb6e184ae25507a9e192ff720121de8794ba736d33dL130-R139)
* Updated progress calculation logic to immediately return 100% when near the end of audio playback, providing a more accurate user experience.
* Modified the buffer analysis call to explicitly set the interval to 0.1 in one location, possibly for a specific use case or override.