### PR TITLE
fix: copy loudness.worklet.js to web dist for CDN access

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -45,6 +45,8 @@ jobs:
           npm run build -w @loudness-worklet/core
           npm run build -w @loudness-worklet/lib
           npm run build -w @loudness-worklet/web
+      - name: Copy worklet to web dist
+        run: cp packages/core/dist/loudness.worklet.js packages/web/dist/loudness.worklet.js
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact


### PR DESCRIPTION
This pull request introduces a small but important change to the deployment workflow. It ensures that the `loudness.worklet.js` file built in the `core` package is copied into the `web` package's distribution directory before deployment.

* Deployment workflow update:
  * Added a step in `.github/workflows/deploy.yaml` to copy `packages/core/dist/loudness.worklet.js` to `packages/web/dist/loudness.worklet.js` after building, ensuring the web distribution includes the latest worklet build.