### PR TITLE
release: v1.6.6

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -45,6 +45,8 @@ jobs:
           npm run build -w @loudness-worklet/core
           npm run build -w @loudness-worklet/lib
           npm run build -w @loudness-worklet/web
+      - name: Copy worklet to web dist
+        run: cp packages/core/dist/loudness.worklet.js packages/web/dist/loudness.worklet.js
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact


### PR DESCRIPTION
This pull request introduces a small but important deployment step to the GitHub Actions workflow. Now, after building the packages, the compiled `loudness.worklet.js` file from the `core` package is copied into the `web` package's distribution directory to ensure it is available for the web deployment.

- Deployment workflow improvement:
  * Added a step to copy `packages/core/dist/loudness.worklet.js` to `packages/web/dist/loudness.worklet.js` in the deployment workflow to make the worklet available in the web build.