### PR TITLE
docs: refine readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,6 @@ A loudness meter for the `Web Audio API`, based on the [ITU-R BS.1770-5](https:/
 - **Versatile Input**: Seamlessly supports both live audio streams ("Microphone/WebRTC") and offline file analysis.
 - **Zero Dependencies**: Lightweight, pure AudioWorklet implementation requiring no external libraries.
 
-## Use Cases
-
-- **Volume Normalization**: Dynamically analyze and harmonize volume levels across multi-source playlists directly in the browser, eliminating the need for server-side processing.
-- **Pre-upload Validation**: Verify if audio files meet platform-specific loudness standards (e.g., -14 LUFS) locally before uploading.
-- **Live Metering**: Build responsive, standard-compliant loudness meters for web-based recorders, conferencing tools, or broadcasting interfaces.
-- **Web Audio Editors**: Integrate professional-grade loudness analysis into browser-based Digital Audio Workstations (DAWs).
-
 ## Installation
 
 ### CDN
@@ -73,7 +66,7 @@ const worklet = new LoudnessWorkletNode(audioContext);
 
 ### Example
 
-This example shows the easiest way to get started with the Loudness Audio Worklet Processor.
+This example shows the easiest way to get started with the `loudness-worklet` by measuring the loudness of a screen share stream with audio (e.g., a YouTube tab).
 
 ```html
 <!DOCTYPE html>
@@ -87,7 +80,7 @@ This example shows the easiest way to get started with the Loudness Audio Workle
       const pre = document.querySelector("pre");
 
       button.onclick = async () => {
-        // Get the screen stream with audio, for example a YouTube tab
+        // Get the display media stream with audio
         const mediaStream = await navigator.mediaDevices.getDisplayMedia({ audio: true });
         const context = new AudioContext();
 
@@ -190,7 +183,6 @@ Nodes are the building blocks of an audio graph, representing audio sources, pro
 `AudioBufferSourceNode` is used to play audio data stored in an `AudioBuffer`, typically for pre-recorded audio files.
 
 ```javascript
-const audioContext = new AudioContext();
 const arrayBuffer = await file.arrayBuffer();
 const audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
 const bufferSource = new AudioBufferSourceNode(audioContext, { buffer: audioBuffer });
@@ -201,7 +193,6 @@ const bufferSource = new AudioBufferSourceNode(audioContext, { buffer: audioBuff
 `MediaStreamAudioSourceNode` is used to play audio from a `MediaStream`, such as a live microphone input or a video element.
 
 ```javascript
-const audioContext = new AudioContext();
 const mediaStream = await navigator.mediaDevices.getUserMedia({ audio: true });
 const mediaStreamSource = new MediaStreamAudioSourceNode(audioContext, { mediaStream });
 ```
@@ -211,7 +202,6 @@ const mediaStreamSource = new MediaStreamAudioSourceNode(audioContext, { mediaSt
 `MediaElementAudioSourceNode` is used to play audio from an HTML `<audio>` or `<video>` element.
 
 ```javascript
-const audioContext = new AudioContext();
 const mediaElement = document.querySelector("audio");
 const elementSource = new MediaElementAudioSourceNode(audioContext, { mediaElement });
 ```
@@ -231,7 +221,7 @@ The `AudioWorkletNode` constructor accepts the following options:
 
 #### Example
 
-Most of the time, you only need to set `processorOptions`.
+Most of the time, you only need to set `processorOptions` or leave it empty.
 
 ```javascript
 const { numberOfChannels, length, sampleRate } = audioBuffer;
@@ -264,6 +254,8 @@ type LoudnessSnapshot = {
   currentMeasurements: LoudnessMeasurements[];
 };
 ```
+
+## Details
 
 ### Units
 
@@ -385,6 +377,7 @@ Validated against **[EBU TECH 3341](https://tech.ebu.ch/publications/tech3341)**
 | seq-3341-3-16bit-v02                 | I = -23.0 ±0.1 LUFS                                         | :white_check_mark: |
 | seq-3341-4-16bit-v02                 | I = -23.0 ±0.1 LUFS                                         | :white_check_mark: |
 | seq-3341-5-16bit-v02                 | I = -23.0 ±0.1 LUFS                                         | :white_check_mark: |
+| seq-3341-6-5channels-16bit           | I = -23.0 ±0.1 LUFS                                         | :white_check_mark: |
 | seq-3341-6-6channels-WAVEEX-16bit    | I = -23.0 ±0.1 LUFS                                         | :white_check_mark: |
 | seq-3341-7_seq-3342-5-24bit          | I = -23.0 ±0.1 LUFS                                         | :white_check_mark: |
 | seq-3341-2011-8_seq-3342-6-24bit-v02 | I = -23.0 ±0.1 LUFS                                         | :white_check_mark: |


### PR DESCRIPTION
This pull request makes several improvements to the `README.md` documentation for the loudness meter library. The changes focus on clarifying usage instructions, improving code examples, and updating validation information. Below are the most important updates:

**Documentation improvements:**

* Removed the "Use Cases" section to streamline the introduction and keep the focus on installation and usage.
* Added a new "Details" section header to better organize the documentation structure.

**Code example enhancements:**

* Updated the main example to clarify that it demonstrates measuring the loudness of a screen share stream (e.g., a YouTube tab), and improved the related code comments for clarity. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L76-R69) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L90-R83)
* Simplified code snippets for node creation by removing redundant `AudioContext` initializations, making the examples more concise and focused. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L193) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L204) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L214)
* Clarified that `processorOptions` in the `AudioWorkletNode` constructor can usually be set or left empty, improving guidance for typical usage.

**Validation updates:**

* Added a new test case (`seq-3341-6-5channels-16bit`) to the validation table, confirming compliance with EBU TECH 3341 standards for 5-channel audio.