### PR TITLE
fix: update permissions for GitHub Actions workflows to enable deploy…

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -28,6 +28,8 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,12 +12,14 @@ on:
 # OIDC authentication
 permissions:
   id-token: write # Required for OIDC
-  contents: read
+  contents: write
 
 jobs:
   # Single publish job since we're just publishing
   publish:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for deployment and publishing to ensure compatibility with Node.js 24 for JavaScript actions and modifies permissions for publishing. The most important changes are:

**Workflow Environment Updates:**

* Both `.github/workflows/deploy.yaml` and `.github/workflows/publish.yaml` now set the environment variable `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` to `true`, ensuring JavaScript actions run using Node.js 24. [[1]](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54R31-R32) [[2]](diffhunk://#diff-e81e13daadd1745de51d8b8d85fce1fcd9be355732b64d60a6b56e18c28388caL15-R22)

**Permissions Update:**

* The `contents` permission in `.github/workflows/publish.yaml` was changed from `read` to `write`, allowing the workflow to make changes to repository contents during the publish process.